### PR TITLE
Translate Portuguese strings

### DIFF
--- a/app/Enums/Stripe/CancelSubscriptionEnum.php
+++ b/app/Enums/Stripe/CancelSubscriptionEnum.php
@@ -17,13 +17,13 @@ enum CancelSubscriptionEnum: string implements HasLabel, HasColor, HasDescriptio
     public function getLabel(): string
     {
         return match ($this) {
-            self::CUSTUMER_SERVICE => 'Atendimento Ruim',
-            self::LOW_QUALITY      => 'Baixa Qualidade',
-            self::MISSING_FEATURES => 'Falta Recursos',
-            self::SWITCHED_SERVICE => 'Mudando de Provedor',
-            self::TOO_COMPLEX      => 'Muito Complexo',
-            self::TOO_EXPENSIVE    => 'Muito caro',
-            self::UNUSED           => 'Não Uso',
+            self::CUSTUMER_SERVICE => 'Poor Service',
+            self::LOW_QUALITY      => 'Low Quality',
+            self::MISSING_FEATURES => 'Missing Features',
+            self::SWITCHED_SERVICE => 'Switching Provider',
+            self::TOO_COMPLEX      => 'Too Complex',
+            self::TOO_EXPENSIVE    => 'Too Expensive',
+            self::UNUSED           => 'Not Used',
         };
     }
     public function getColor(): string|array|null
@@ -42,13 +42,13 @@ enum CancelSubscriptionEnum: string implements HasLabel, HasColor, HasDescriptio
     public function getDescription(): string
     {
         return match ($this) {
-            self::CUSTUMER_SERVICE => 'O atendimento ao cliente foi menor do que o esperado',
-            self::LOW_QUALITY      => 'A qualidade ficou abaixo do esperado',
-            self::MISSING_FEATURES => 'Alguns recursos estão faltando',
-            self::SWITCHED_SERVICE => 'Estou mudando para um serviço diferente',
-            self::TOO_COMPLEX      => 'A facilidade de uso foi menor do que o esperado',
-            self::TOO_EXPENSIVE    => 'É muito caro',
-            self::UNUSED           => 'Não uso o serviço o suficiente',
+            self::CUSTUMER_SERVICE => 'Customer service was below expectations',
+            self::LOW_QUALITY      => 'Quality was below expectations',
+            self::MISSING_FEATURES => 'Some features are missing',
+            self::SWITCHED_SERVICE => 'Switching to a different service',
+            self::TOO_COMPLEX      => 'Ease of use was below expectations',
+            self::TOO_EXPENSIVE    => 'It is too expensive',
+            self::UNUSED           => 'I do not use the service enough',
 
         };
     }

--- a/app/Enums/Stripe/Refunds/ReasonRefundStatusEnum.php
+++ b/app/Enums/Stripe/Refunds/ReasonRefundStatusEnum.php
@@ -17,13 +17,13 @@ enum ReasonRefundStatusEnum: string implements HasLabel
     public function getLabel(): string
     {
         return match ($this) {
-            self::CHARGE_FOR_PENDING_REFUND_DISPUTED => 'Constestação de reembolso',
-            self::DECLINED                           => 'Reembolso recusado',
-            self::EXPIRED_OR_CANCELED_CARD           => 'Expirada ou Cancelada',
-            self::INSUFFICIENT_FUNDS                 => 'Saldo Insuficiente',
-            self::LOST_OR_STOLEN_CARD                => 'Perda ou roubo do cartão',
-            self::MERCANT_REQUEST                    => 'Falha no reembolso',
-            self::UNKNOWN                            => ' falhou por motivo desconhecido',
+            self::CHARGE_FOR_PENDING_REFUND_DISPUTED => 'Refund dispute',
+            self::DECLINED                           => 'Refund declined',
+            self::EXPIRED_OR_CANCELED_CARD           => 'Expired or Cancelled',
+            self::INSUFFICIENT_FUNDS                 => 'Insufficient funds',
+            self::LOST_OR_STOLEN_CARD                => 'Lost or stolen card',
+            self::MERCANT_REQUEST                    => 'Refund failure',
+            self::UNKNOWN                            => 'Failed for unknown reason',
         };
     }
 

--- a/app/Enums/Stripe/Refunds/RefundStatusEnum.php
+++ b/app/Enums/Stripe/Refunds/RefundStatusEnum.php
@@ -15,11 +15,11 @@ enum RefundStatusEnum: string implements HasLabel, HasColor
     public function getLabel(): string
     {
         return match ($this) {
-            self::PENDING         => 'Pendente',
-            self::REQUIRES_ACTION => 'Requer Ação',
-            self::SUCCEEDED       => 'Realizada',
-            self::FAILED          => 'Falhou',
-            self::CANCELED        => 'Cancelado',
+            self::PENDING         => 'Pending',
+            self::REQUIRES_ACTION => 'Requires Action',
+            self::SUCCEEDED       => 'Succeeded',
+            self::FAILED          => 'Failed',
+            self::CANCELED        => 'Canceled',
         };
     }
 

--- a/app/Enums/Stripe/Refunds/RefundSubscriptionEnum.php
+++ b/app/Enums/Stripe/Refunds/RefundSubscriptionEnum.php
@@ -14,10 +14,10 @@ enum RefundSubscriptionEnum: string implements HasLabel, HasColor
     public function getLabel(): string
     {
         return match ($this) {
-            self::DUPLICATE                 => 'Duplicada',
-            self::FRAUDULENT                => 'Fraude',
-            self::REQUESTED_BY_CUSTOMER     => 'Solicitada pelo Cliente',
-            self::EXPIRED_UNCAPTURED_CHARGE => 'Cobrança Expirada',
+            self::DUPLICATE                 => 'Duplicate',
+            self::FRAUDULENT                => 'Fraudulent',
+            self::REQUESTED_BY_CUSTOMER     => 'Requested by Customer',
+            self::EXPIRED_UNCAPTURED_CHARGE => 'Expired Charge',
         };
     }
 

--- a/app/Enums/Stripe/SubscriptionStatusEnum.php
+++ b/app/Enums/Stripe/SubscriptionStatusEnum.php
@@ -18,14 +18,14 @@ enum SubscriptionStatusEnum: string implements HasLabel, HasColor
     public function getLabel(): string
     {
         return match ($this) {
-            self::INCOMPLETE         => 'Em Validação',
-            self::TRIALING           => 'Período Teste',
-            self::ACTIVE             => 'Ativa',
-            self::INCOMPLETE_EXPIRED => 'Cancelado',
-            self::PAST_DUE           => 'Aguardando Pagamento',
-            self::UNPAID             => 'Cartão Inválido',
-            self::CANCELED           => 'Cancelado',
-            self::PAUSED             => 'Pausado',
+            self::INCOMPLETE         => 'Pending',
+            self::TRIALING           => 'Trialing',
+            self::ACTIVE             => 'Active',
+            self::INCOMPLETE_EXPIRED => 'Canceled',
+            self::PAST_DUE           => 'Awaiting Payment',
+            self::UNPAID             => 'Card Declined',
+            self::CANCELED           => 'Canceled',
+            self::PAUSED             => 'Paused',
 
         };
     }

--- a/app/Filament/Admin/Resources/OrganizationResource.php
+++ b/app/Filament/Admin/Resources/OrganizationResource.php
@@ -22,7 +22,7 @@ class OrganizationResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-building-office-2';
 
-    protected static ?string $navigationGroup = 'Administração';
+    protected static ?string $navigationGroup = 'Administration';
 
     protected static ?string $navigationLabel = 'Tenant';
 

--- a/app/Filament/Admin/Resources/OrganizationResource/RelationManagers/SubscriptionRefundsRelationManager.php
+++ b/app/Filament/Admin/Resources/OrganizationResource/RelationManagers/SubscriptionRefundsRelationManager.php
@@ -12,11 +12,11 @@ class SubscriptionRefundsRelationManager extends RelationManager
 {
     protected static string $relationship = 'subscription_refunds';
 
-    protected static ?string $modelLabel = 'Reembolsos';
+    protected static ?string $modelLabel = 'Refund';
 
-    protected static ?string $modelLabelPlural = "Reembolsos";
+    protected static ?string $modelLabelPlural = 'Refunds';
 
-    protected static ?string $title = 'Reembolsos da Subscription';
+    protected static ?string $title = 'Subscription Refunds';
 
     public function form(Form $form): Form
     {
@@ -38,30 +38,30 @@ class SubscriptionRefundsRelationManager extends RelationManager
                     ->searchable(),
 
                 TextColumn::make('amount')
-                    ->label('Valor')
+                    ->label('Amount')
                     ->sortable()
                     ->searchable()
                     ->alignCenter()
                     ->formatStateUsing(fn ($state) => 'R$ ' . number_format($state / 100, 2, ',', '.')),
 
                 TextColumn::make('reason')
-                    ->label('Motivo')
+                    ->label('Reason')
                     ->alignCenter()
                     ->badge()
                     ->searchable(),
 
                 TextColumn::make('failure_reason')
-                    ->label('Motivo')
+                    ->label('Reason')
                     ->visible(fn ($record) => $record && $record->failure_reason !== null)
                     ->searchable(),
 
                 TextColumn::make('reference')
-                    ->label('Referência')
+                    ->label('Reference')
                     ->alignCenter()
                     ->searchable(),
 
                 TextColumn::make('created_at')
-                    ->label('Criado em')
+                    ->label('Created at')
                     ->dateTime('d/m/Y H:m:s')
                     ->alignCenter()
                     ->searchable(),

--- a/app/Filament/Admin/Resources/OrganizationResource/RelationManagers/SubscriptionRelationManager.php
+++ b/app/Filament/Admin/Resources/OrganizationResource/RelationManagers/SubscriptionRelationManager.php
@@ -98,7 +98,7 @@ class SubscriptionRelationManager extends RelationManager
             ->headerActions([])
             ->actions([
                 ActionGroup::make([
-                    Action::make('Cancelar Assinatura')
+                    Action::make('Cancel Subscription')
                         ->requiresConfirmation()
                         ->action(function (Action $action, $record, array $data) {
                             $cancellationService = new CancelSubscriptionService();
@@ -107,21 +107,21 @@ class SubscriptionRelationManager extends RelationManager
                         ->color('danger')
                         ->icon('heroicon-o-key'),
 
-                    Action::make('Gerar Reembolso')
+                    Action::make('Generate Refund')
                         ->requiresConfirmation()
                         ->form([
 
-                            Fieldset::make('Dados do Plano')
+                            Fieldset::make('Plan Data')
                                 ->schema([
                                     TextInput::make('stripe_period')
-                                        ->label('Tipo do Plano')
+                                        ->label('Plan Type')
                                         ->readOnly()
                                         ->default(function ($record) {
                                             return $record->price->interval;
                                         }),
 
                                     TextInput::make('stripe_price')
-                                        ->label('Valor do Plano')
+                                        ->label('Plan Value')
                                         ->readOnly()
                                         ->default(function ($record) {
                                             $price = $record->price ? $record->price->unit_amount : 0;
@@ -130,11 +130,11 @@ class SubscriptionRelationManager extends RelationManager
                                         }),
                                 ])->columns(2),
 
-                            Fieldset::make('Valores')
+                            Fieldset::make('Values')
                                 ->schema([
 
                                     Money::make('amount')
-                                        ->label('Devolver')
+                                        ->label('Refund Amount')
                                         ->default('100,00')
                                         ->required()
                                         ->rule(function ($get) {
@@ -145,28 +145,28 @@ class SubscriptionRelationManager extends RelationManager
                                         })
                                         ->validationAttribute('amount')
                                         ->validationMessages([
-                                            'lte' => 'O valor não pode ser maior que o valor do plano.',
+                                            'lte' => 'The amount cannot be greater than the plan value.',
                                         ]),
 
                                     Select::make('currency')
-                                        ->label('Moeda')
+                                        ->label('Currency')
                                         ->options(ProductCurrencyEnum::class)
                                         ->required(),
 
                                 ])->columns(2),
 
-                            Fieldset::make('Motivo do Cancelamento')
+                            Fieldset::make('Cancellation Reason')
                                 ->schema([
                                     Select::make('reason')
-                                        ->label('Selecione o Motivo')
+                                        ->label('Select the Reason')
                                         ->options(RefundSubscriptionEnum::class)
                                         ->required(),
                                 ])->columns(1),
 
-                            Fieldset::make('Id Pagamento')
+                            Fieldset::make('Payment ID')
                                 ->schema([
                                     TextInput::make('payment_intent')
-                                        ->label('Id Pagamento')
+                                        ->label('Payment ID')
                                         ->readOnly()
                                         ->default(function ($record) {
                                             return $record->payment_intent;
@@ -175,7 +175,7 @@ class SubscriptionRelationManager extends RelationManager
                         ])
 
                         ->requiresConfirmation()
-                        ->modalHeading('Gerar Reembolso')
+                        ->modalHeading('Generate Refund')
                         ->modalDescription()
                         ->slideOver()
                         ->color('warning')
@@ -187,25 +187,25 @@ class SubscriptionRelationManager extends RelationManager
                                 //$refundService->processRefund($record->id, $data);
 
                                 Notification::make()
-                                    ->title('Reembolso Gerado')
-                                    ->body('Reembolso gerado com Sucesso')
+                                    ->title('Refund Generated')
+                                    ->body('Refund generated successfully')
                                     ->success()
                                     ->send();
                             } catch (\Exception $e) {
 
                                 Notification::make()
-                                    ->title('Erro ao Criar Preço')
-                                    ->body('Ocorreu um erro ao gerar reembolso na Stripe: ' . $e->getMessage())
+                                    ->title('Error Creating Price')
+                                    ->body('An error occurred while generating the refund in Stripe: ' . $e->getMessage())
                                     ->danger()
                                     ->send();
                             }
                         }),
 
-                    Action::make('Baixar Invoice')
-                        ->label('Baixar Invoice')
+                    Action::make('Download Invoice')
+                        ->label('Download Invoice')
                         ->icon('heroicon-o-document-arrow-down')
                         ->url(fn ($record) => $record->invoice_pdf)
-                        ->tooltip('Baixar PDF da Fatura')
+                        ->tooltip('Download Invoice PDF')
                         ->color('primary'),
 
                 ])

--- a/app/Filament/Admin/Resources/OrganizationResource/Widgets/StatsTenantOverview.php
+++ b/app/Filament/Admin/Resources/OrganizationResource/Widgets/StatsTenantOverview.php
@@ -13,29 +13,29 @@ class StatsTenantOverview extends BaseWidget
     protected function getStats(): array
     {
         return [
-            Stat::make('Tenants Cadastrados', Organization::count())
-                ->description('Total desde o início')
+            Stat::make('Registered Tenants', Organization::count())
+                ->description('Total since the beginning')
                 ->descriptionIcon('heroicon-s-users')
                 ->color('warning')
                 ->chart([7, 3, 4, 5, 6, 3, 5, 8]),
 
             Stat::make('Total tenants', Subscription::where('stripe_status', 'active')->count())
-                ->description('Atualmente ativos')
+                ->description('Currently active')
                 ->descriptionIcon('heroicon-s-check-circle')
                 ->color('info')
                 ->chart([7, 3, 4, 5, 6, 3, 5, 3]),
 
             Stat::make(
-                'Tenants Cancelados',
+                'Cancelled Tenants',
                 Subscription::where('stripe_status', 'canceled')->count()
             )
-                    ->description('Cancelados até agora')
+                    ->description('Cancelled so far')
                     ->descriptionIcon('heroicon-s-exclamation-circle')
                     ->color('danger')
                     ->chart([3, 2, 1, 4, 2, 1, 3, 2]),
 
-            Stat::make('Valor Faturado', number_format(Price::sum('unit_amount'), 2, ',', '.'))
-                ->description('Acumulado no período')
+            Stat::make('Billed Amount', number_format(Price::sum('unit_amount'), 2, ',', '.'))
+                ->description('Accumulated in the period')
                 ->color('success')
                 ->descriptionIcon('heroicon-s-currency-dollar')
                 ->chart([7, 3, 4, 5, 6, 3, 5, 5]),

--- a/app/Filament/Admin/Resources/TicketResource.php
+++ b/app/Filament/Admin/Resources/TicketResource.php
@@ -22,7 +22,7 @@ class TicketResource extends Resource
 
     protected static ?string $navigationIcon = 'fas-comment-dots';
 
-    protected static ?string $navigationGroup = 'Administração';
+    protected static ?string $navigationGroup = 'Administration';
 
     protected static ?string $navigationLabel = 'Solicitações';
 
@@ -45,15 +45,15 @@ class TicketResource extends Resource
         return $form
             ->schema([
 
-                Fieldset::make('Empresa')
+                Fieldset::make('Company')
                     ->schema([
                         TextInput::make('title')
-                            ->label('Assunto')
+                            ->label('Subject')
                             ->required()
                             ->maxLength(50),
 
                         Select::make('organization_id')
-                            ->label('Empresa')
+                            ->label('Company')
                             ->required()
                             ->options(Organization::all()->pluck('name', 'id')) // Exibe todas as organizações
                             ->afterStateUpdated(function (Set $set, $state) {
@@ -62,7 +62,7 @@ class TicketResource extends Resource
                             }),
 
                         Select::make('user_id')
-                            ->label('Usuario')
+                            ->label('User')
                             ->searchable()   // Permite pesquisa
                             ->preload()      // Carrega os dados de forma antecipada
                             ->live()          // Atualiza as opções em tempo real
@@ -87,7 +87,7 @@ class TicketResource extends Resource
                             }),
                     ])->columns(3),
 
-                Fieldset::make('Classificação')
+                Fieldset::make('Classification')
                     ->schema([
                         Select::make('status')
                             ->label('Status')
@@ -96,35 +96,35 @@ class TicketResource extends Resource
                             ->required(),
 
                         Select::make('type')
-                            ->label('Tipo')
+                            ->label('Type')
                             ->options(TicketTypeEnum::class)
                             ->searchable()
                             ->required(),
 
                         Select::make('priority')
-                            ->label('Prioridade')
+                            ->label('Priority')
                             ->options(TicketPriorityEnum::class)
                             ->searchable()
                             ->required(),
 
                     ])->columns(3),
 
-                Fieldset::make('Detalhes do Ticket')
+                Fieldset::make('Ticket Details')
                     ->schema([
                         RichEditor::make('description')
-                            ->label('Detalhamento')
+                            ->label('Details')
                             ->required()
                             ->columnSpanFull(),
                     ]),
 
-                Fieldset::make('Anexos')
+                Fieldset::make('Attachments')
                     ->schema([
                         FileUpload::make('file')
                             ->multiple()
-                            ->label('Arquivos'),
+                            ->label('Files'),
 
                         FileUpload::make('image_path')
-                            ->label('Imagens')
+                            ->label('Images')
                             ->image()
                             ->imageEditor(),
                     ])->columns(2),
@@ -137,7 +137,7 @@ class TicketResource extends Resource
         return $table
             ->columns([
                 TextColumn::make('id')
-                    ->label('Solicitação')
+                    ->label('Request')
                     ->alignCenter()
                     ->sortable(),
 
@@ -146,12 +146,12 @@ class TicketResource extends Resource
                     ->numeric()
                     ->sortable(),
                 TextColumn::make('user.name')
-                    ->label('Solicitante')
+                    ->label('Requester')
                     ->numeric()
                     ->sortable(),
 
                 TextColumn::make('title')
-                    ->label('Assunto')
+                    ->label('Subject')
                     ->searchable(),
 
                 TextColumn::make('status')
@@ -161,19 +161,19 @@ class TicketResource extends Resource
                     ->sortable(),
 
                 TextColumn::make('priority')
-                    ->label('Prioridade')
+                    ->label('Priority')
                     ->alignCenter()
                     ->badge()
                     ->sortable(),
 
                 TextColumn::make('type')
-                    ->label('Tipo')
+                    ->label('Type')
                     ->alignCenter()
                     ->badge()
                     ->sortable(),
 
                 TextColumn::make('lifetime')
-                    ->label('Tempo de Vida')
+                    ->label('Lifetime')
                     ->getStateUsing(function (Model $record) {
                         $createdAt = Carbon::parse($record->created_at);
                         $closedAt  = $record->closed_at ? Carbon::parse($record->closed_at) : now();
@@ -185,19 +185,19 @@ class TicketResource extends Resource
                     ->sortable(),
 
                 TextColumn::make('created_at')
-                    ->label('Criado em')
+                    ->label('Created at')
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
 
                 TextColumn::make('closed_at')
-                    ->label('Fechado em')
+                    ->label('Closed at')
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
 
                 TextColumn::make('updated_at')
-                    ->label('Atualizado em')
+                    ->label('Updated at')
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),

--- a/app/Filament/Admin/Resources/TicketResource/Pages/EditTicket.php
+++ b/app/Filament/Admin/Resources/TicketResource/Pages/EditTicket.php
@@ -22,24 +22,24 @@ class EditTicket extends EditRecord
     }
     protected function afterSave(): void
     {
-        $ticket = $this->record->fresh(); // Recarrega o ticket atualizado do banco de dados
+        $ticket = $this->record->fresh(); // Reload the updated ticket from the database
 
-        $status = strtolower(trim($ticket->status->value)); // Normaliza o valor do enum
+        $status = strtolower(trim($ticket->status->value)); // Normalize enum value
 
         if (in_array($status, ['resolved', 'closed'])) {
-            $ticket->update(['closed_at' => now()]); // Atualiza diretamente o campo 'closed_at' no banco de dados
+            $ticket->update(['closed_at' => now()]); // Directly update the 'closed_at' field
         }
 
-        // Buscar a instância do usuário relacionado ao ticket
+        // Find the user instance related to the ticket
         $user = $ticket->user;
 
-        if ($user) { // Certifique-se de que o usuário existe
+        if ($user) { // Ensure the user exists
             Notification::make()
-            ->title('Chamado Atualizado')
-            ->body("Seu Chamado de N. {$ticket->id} foi atualizado. Confira as atualizações.")
+            ->title('Ticket Updated')
+            ->body("Your ticket No. {$ticket->id} has been updated. Check the updates.")
             ->success()
             ->actions([
-                Action::make('Visualizar')
+                Action::make('View')
                     ->url(TicketResource::getUrl('view', ['record' => $ticket->id]))
                     ->button(),
             ])

--- a/app/Filament/Admin/Resources/WebhookEventResource/Widgets/StatsWebhookOverview.php
+++ b/app/Filament/Admin/Resources/WebhookEventResource/Widgets/StatsWebhookOverview.php
@@ -15,24 +15,24 @@ class StatsWebhookOverview extends BaseWidget
         $successCount = WebhookEvent::where('status', 'success')->count();
         $failureCount = WebhookEvent::where('status', 'failed')->count();
 
-        // Calcula a média de falhas sobre os sucessos, evitando divisão por zero
+        // Calculate the average failure rate over successes, avoiding division by zero
         $failureRate = $successCount > 0 ? $failureCount / $successCount : 0;
 
         return [
-            Stat::make('Webhooks com Falha', $failureCount)
+            Stat::make('Failed Webhooks', $failureCount)
                 ->description('Total')
                 ->descriptionIcon('heroicon-s-bug-ant')
                 ->color('danger')
                 ->chart([7, 3, 4, 5, 6, 3, 5, 8]),
 
-            Stat::make('Webhooks dom Sucesso', $successCount)
+            Stat::make('Successful Webhooks', $successCount)
                 ->description('Total')
                 ->descriptionIcon('heroicon-s-check-badge')
                 ->color('success')
                 ->chart([7, 3, 4, 5, 6, 3, 5, 3]),
 
-            Stat::make('Média de Falhas', number_format($failureRate, 2) . ' %')
-                ->description('Falhas / Sucesso')
+            Stat::make('Failure Rate', number_format($failureRate, 2) . ' %')
+                ->description('Failures / Successes')
                 ->color('warning')
                 ->descriptionIcon('heroicon-s-exclamation-triangle')
                 ->chart([3, 2, 1, 4, 2, 1, 3, 2]),

--- a/app/Filament/App/Resources/TicketResource/Pages/CreateTicket.php
+++ b/app/Filament/App/Resources/TicketResource/Pages/CreateTicket.php
@@ -22,18 +22,18 @@ class CreateTicket extends CreateRecord
 
     protected function afterCreate(): void
     {
-        $ticket = $this->record; // Recupera o ticket recém-criado ou atualizado
+        $ticket = $this->record; // Retrieve the newly created or updated ticket
 
         Notification::make()
-            ->title('Chamado Registrado com Sucesso')
-            ->body("Seu Chamado de N. {$ticket->id} foi registrado com sucesso. Em breve será respondido pela equipe.")
+            ->title('Ticket Successfully Created')
+            ->body("Your ticket No. {$ticket->id} has been successfully created. It will be answered shortly.")
             ->success()
             ->actions([
-                Action::make('Visualizar')
+                Action::make('View')
                     ->url(TicketResource::getUrl('view', ['record' => $ticket->id])),
 
             ])
-            ->sendToDatabase(Auth::user()); // Envia para o usuário relacionado ao ticket
+            ->sendToDatabase(Auth::user()); // Sends notification to the user related to the ticket
 
     }
 

--- a/app/Filament/App/Resources/UserResource.php
+++ b/app/Filament/App/Resources/UserResource.php
@@ -50,7 +50,7 @@ class UserResource extends Resource
                             ->prefixIcon('fas-envelope')
                             ->unique(User::class, 'email', ignoreRecord: true)
                             ->validationMessages([
-                                'unique' => 'E-mail já cadastrado.',
+                                'unique' => 'Email already registered.',
                             ])
                             ->required()
                             ->maxLength(255),

--- a/app/Filament/App/Resources/WhatsappInstanceResource/RelationManagers/InstanceTypebotsRelationManager.php
+++ b/app/Filament/App/Resources/WhatsappInstanceResource/RelationManagers/InstanceTypebotsRelationManager.php
@@ -15,27 +15,27 @@ class InstanceTypebotsRelationManager extends RelationManager
 {
     protected static string $relationship = 'InstanceTypebots';
 
-    protected static ?string $modelLabel = 'Robô TypeBot';
+    protected static ?string $modelLabel = 'TypeBot Bot';
 
     protected static ?string $modelLabelPlural = "TypeBots";
 
-    protected static ?string $title = 'Robôs TypeBot';
+    protected static ?string $title = 'TypeBot Bots';
 
     public function form(Form $form): Form
     {
         return $form
             ->schema([
-                Section::make('Dados Basicos do typebot')
+                Section::make('Basic Typebot Data')
                     ->schema([
 
                         TextInput::make('name')
-                            ->label('Descrição do Robô')
+                            ->label('Bot Description')
                             ->prefixIcon('fas-id-card')
                             ->required()
                             ->maxLength(255),
 
                         TextInput::make('url')
-                            ->label('URL do typebot')
+                            ->label('Typebot URL')
                             ->prefix('https://')
                             ->required()
                             ->maxLength(255),
@@ -48,11 +48,11 @@ class InstanceTypebotsRelationManager extends RelationManager
 
                     ])->columns(3),
 
-                Section::make('Dados de Disparo')
+                Section::make('Trigger Data')
                     ->schema([
 
                         Select::make('trigger_type')
-                            ->label('Tipo de Gatilho')
+                            ->label('Trigger Type')
                             ->required()
                             ->reactive()
                             ->live()
@@ -62,12 +62,12 @@ class InstanceTypebotsRelationManager extends RelationManager
                             ->hidden(fn ($get) => $get('trigger_type') != 'keyword')
                             ->required()
                             ->reactive()
-                            ->label('Operador de Gatilho')
+                            ->label('Trigger Operator')
                             ->options(TriggerOperatorEnum::class),
 
                         TextInput::make('trigger_value')
                             ->hidden(fn ($get) => !in_array($get('trigger_type'), ['advanced', 'keyword']))
-                            ->label('Valor do Gatilho')
+                            ->label('Trigger Value')
                             ->prefixIcon('fas-keyboard')
                             ->reactive()
                             ->required()
@@ -75,58 +75,58 @@ class InstanceTypebotsRelationManager extends RelationManager
 
                     ])->columns(3),
 
-                Section::make('Configurações Gerais')
+                Section::make('General Settings')
                 ->schema([
 
                     TextInput::make('expire')
-                        ->label('Expirar em minutos')
+                        ->label('Expire in minutes')
                         ->prefixIcon('fas-clock')
                         ->numeric()
                         ->required(),
 
                     TextInput::make('keyword_finish')
-                        ->label('Palavra-chave de Finalização')
+                        ->label('Finish Keyword')
                         ->prefixIcon('fas-arrow-right-from-bracket')
                         ->required()
                         ->maxLength(255),
 
                     TextInput::make('delay_message')
-                        ->label('Atraso Padrão (Milisegundos)')
+                        ->label('Default Delay (Milliseconds)')
                         ->prefixIcon('fas-clock')
                         ->required()
                         ->numeric(),
 
                     TextInput::make('unknown_message')
-                        ->label('Mensagem Desconhecida')
+                        ->label('Unknown Message')
                         ->prefixIcon('fas-question')
                         ->required()
                         ->maxLength(30),
 
                     TextInput::make('debounce_time')
-                        ->label('Tempo de Debounce')
+                        ->label('Debounce Time')
                         ->prefixIcon('fas-clock')
                         ->required()
                         ->numeric(),
 
                 ])->columns(3),
 
-                Section::make('Opções Gerais')
+                Section::make('General Options')
                 ->schema([
 
                     ToggleButtons::make('listening_from_me')
-                        ->label('Ouvindo de mim')
+                        ->label('Listening from me')
                         ->inline()
                         ->boolean()
                         ->required(),
 
                     ToggleButtons::make('stop_bot_from_me')
-                        ->label('Parar bot por mim')
+                        ->label('Stop bot by me')
                         ->inline()
                         ->boolean()
                         ->required(),
 
                     ToggleButtons::make('keep_open')
-                        ->label('Manter aberto')
+                        ->label('Keep open')
                         ->inline()
                         ->boolean()
                         ->required(),
@@ -142,19 +142,19 @@ class InstanceTypebotsRelationManager extends RelationManager
             ->columns([
 
                 TextColumn::make('name')
-                    ->label('Descrição do'),
+                    ->label('Description'),
 
                 TextColumn::make('url')
                     ->label('URL'),
 
                 TextColumn::make('type_bot')
-                    ->label('Codigo do Typebot'),
+                    ->label('Typebot Code'),
 
                 TextColumn::make('id_typebot')
-                    ->label('Id do Bot'),
+                    ->label('Bot ID'),
 
                 ToggleColumn::make('is_active')
-                    ->label('Ativo')
+                    ->label('Active')
                     ->alignCenter(),
 
             ])

--- a/app/Filament/Pages/Auth/Login.php
+++ b/app/Filament/Pages/Auth/Login.php
@@ -30,7 +30,7 @@ class Login extends BaseAuth
     protected function getUsernameFormComponent(): Component
     {
         return TextInput::make('username')
-            ->label('Email de Cadastro')
+            ->label('Registered Email')
             ->required()
             ->autocomplete()
             ->autofocus()

--- a/app/Filament/Pages/Backup/Backup.php
+++ b/app/Filament/Pages/Backup/Backup.php
@@ -8,7 +8,7 @@ class Backup extends BaseBackups
 {
     protected static ?string $navigationIcon = 'heroicon-o-circle-stack';
 
-    protected static ?string $navigationGroup = 'Administração';
+    protected static ?string $navigationGroup = 'Administration';
 
     protected static ?string $navigationLabel = 'Sistema';
 

--- a/app/Livewire/ColorProfileComponent.php
+++ b/app/Livewire/ColorProfileComponent.php
@@ -34,13 +34,13 @@ class ColorProfileComponent extends Component implements HasForms
     {
         return $form
             ->schema([
-                Section::make('Cor do Tema')
+                Section::make('Theme Color')
                     ->aside()
-                    ->description('Escolha a cor do tema')
+                    ->description('Choose the theme color')
                     ->schema([
 
                         ColorPicker::make('settings.color')
-                            ->label('Cor do tema')
+                            ->label('Theme Color')
                             ->columnSpanFull()
                             ->inLineLabel()
                             ->default('#f59e0b'),

--- a/app/Services/Stripe/Subscription/CancelSubscriptionService.php
+++ b/app/Services/Stripe/Subscription/CancelSubscriptionService.php
@@ -37,16 +37,16 @@ class CancelSubscriptionService
             ]);
 
             Notification::make()
-                ->title('Assinatura Cancelada')
-                ->body('Assinatura cancelada com sucesso!')
+                ->title('Subscription Cancelled')
+                ->body('Subscription cancelled successfully!')
                 ->success()
                 ->send();
 
         } catch (\Exception $e) {
 
             Notification::make()
-                ->title('Erro ao Cancelar')
-                ->body('Ocorreu um erro ao cancelar a assinatura. Tente novamente mais tarde.')
+                ->title('Error Cancelling')
+                ->body('An error occurred while cancelling the subscription. Please try again later.')
                 ->danger()
                 ->send();
 


### PR DESCRIPTION
## Summary
- translate various Portuguese UI strings to English
- update notification messages, form field labels, and stat descriptions
- normalize navigation labels

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Tests\Feature\ExampleTest::test_the_application_returns_a_successful_response)*

------
https://chatgpt.com/codex/tasks/task_e_68891394edec8320bd6730d12953d0c2